### PR TITLE
Change cpu limit for terminal-cargo

### DIFF
--- a/capability-limitrange/README.md
+++ b/capability-limitrange/README.md
@@ -1,0 +1,21 @@
+# Capability Limit Range
+
+## Overview
+
+This script should be run to apply a limit range to all namespaces.
+
+## How does it work
+
+The script loops over all namespaces, excluding any exceptions, and applies the limitrange.yaml to each namespace. 
+
+The script then looks for .yaml files in the exceptions folder and applies them.
+
+## Making exceptions
+
+Copy the limitrange.yaml and place it in the exceptions folder as namespace-name-here.yaml. Make sure you 
+add the namespace name into the file under metadata
+
+## Usage
+
+Ensure your Kubernetes context is set correctly (logged in as CloudAdmin user), make sure that 
+`bulk-apply-limitrange.sh` is executable on your system and run the script.

--- a/capability-limitrange/bulk-apply-limitrange.sh
+++ b/capability-limitrange/bulk-apply-limitrange.sh
@@ -2,11 +2,19 @@
 
 set -euo pipefail
 
-# Get all namespaces, but exclude kube-system and monitoring
-NAMESPACES=$(kubectl get ns --no-headers=true | awk '!/kube-system|monitoring/{print $1}')
+# Get all namespaces, but exclude kube-system and monitoring plus namespaces that have exceptions
+NAMESPACES=$(kubectl get ns --no-headers=true | awk '!/kube-system|monitoring|terminal-cargoallocati-zamrl/{print $1}')
 
+# Apply to all namespaces
 for NS in $NAMESPACES
 do
 	echo "Applying limitrange in namespace: $NS"
 	kubectl -n $NS apply -f limitrange.yaml
+done
+
+# Apply exceptions
+for file in `ls exceptions | grep .yaml`
+do
+	echo "Applying: $file"
+	kubectl apply -f exceptions/$file
 done

--- a/capability-limitrange/exceptions/terminal-cargoallocati-zamrl.yaml
+++ b/capability-limitrange/exceptions/terminal-cargoallocati-zamrl.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: admission-resources
+  namespace: terminal-cargoallocati-zamrl
+spec:
+  limits:
+    - type: Container
+      default:
+        cpu: 500m
+        memory: 256Mi
+      defaultRequest:
+        memory: 64Mi
+        cpu: 20m
+      min:
+        cpu: 1m
+        memory: 1Mi
+      max:
+        memory: 4Gi
+        cpu: 4000m
+      maxLimitRequestRatio:
+        cpu: 100
+        memory: 100
+    - type: Pod
+      min:
+        cpu: 1m
+        memory: 1Mi
+      max:
+        memory: 4Gi
+        cpu: 4000m

--- a/capability-limitrange/exceptions/terminal-cargoallocati-zamrl.yaml
+++ b/capability-limitrange/exceptions/terminal-cargoallocati-zamrl.yaml
@@ -18,7 +18,7 @@ spec:
         memory: 1Mi
       max:
         memory: 4Gi
-        cpu: 4000m
+        cpu: 2000m
       maxLimitRequestRatio:
         cpu: 100
         memory: 100
@@ -28,4 +28,4 @@ spec:
         memory: 1Mi
       max:
         memory: 4Gi
-        cpu: 4000m
+        cpu: 2000m


### PR DESCRIPTION
Changing the limit from 4CPU to 2CPU as we only have 4 CPU's per node and a ReplicaSet deployment of sufficient replicas could cause us some issue scheduling other loads