### PR TITLE
Avoid overwriting `saml` profile with assume.

### DIFF
--- a/k8s-service-account-config-to-ssm/README.md
+++ b/k8s-service-account-config-to-ssm/README.md
@@ -8,6 +8,7 @@ After creation of the file the tool automatically provisions the kubernetes conf
 * [jq](https://stedolan.github.io/jq/)
 * [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html)
 * AWS CLI Credentials for Prime AWS Account
+* [Go AWS SSO](https://github.com/theurichde/go-aws-sso), v1.3.0 or greater.
 
 ### Getting Kubeconfig for Hellman cluster
 The Kubeconfig file for the Hellman cluster can be found in DFDS 1Password account.

--- a/k8s-service-account-config-to-ssm/kube-config-generator.sh
+++ b/k8s-service-account-config-to-ssm/kube-config-generator.sh
@@ -14,7 +14,7 @@ SECRET_NAME="$CAPABILITY_ROOT_ID-vstsuser-token"
 KUBE_ROLE="$CAPABILITY_ROOT_ID-fullaccess"
 CAPABILITY_AWS_ACCOUNT_ID=$ACCOUNT_ID
 CAPABILITY_AWS_ROLE_SESSION="kube-config-paramstore"
-AWS_PROFILE="saml"
+AWS_PROFILE="saml-assume-kube-config-generator"
 SSO_START_URL="https://dfds.awsapps.com/start"
 SSO_REGION="eu-west-1"
 


### PR DESCRIPTION
If your are original profile is named `saml` the assume call overwrites it and then the kubectl commands fail.